### PR TITLE
Update released-2025-h1-cumulative-update-for-exchange-server.md

### DIFF
--- a/source/_posts/released-2025-h1-cumulative-update-for-exchange-server.md
+++ b/source/_posts/released-2025-h1-cumulative-update-for-exchange-server.md
@@ -63,7 +63,7 @@ CU15 には、[2024 年 11 月の SU](https://techcommunity.microsoft.com/blog/e
 
 ### リマインダー: 拡張保護が既定で有効化されています
 
-お客様が古い CU からアップグレードする際のリマインダーとして、Exchange 2019 CU14 以降、CU をインストールした後に拡張保護が既定で有効になります。詳細および拡張保護をオプト アウトする方法については、[このブログ記事](https://techcommunity.microsoft.com/blog/exchange/released-2024-h1-cumulative-update-for-exchange-server/4047506)をご覧ください。
+お客様が古い CU からアップグレードする際のリマインダーとして、Exchange 2019 CU14 以降、CU をインストールした後に拡張保護が既定で有効になります。SSL オフロードを使用する場合など、拡張保護がサポートされないシナリオもあります。詳細および拡張保護をオプト アウトする方法については、[このブログ記事](https://techcommunity.microsoft.com/blog/exchange/released-2024-h1-cumulative-update-for-exchange-server/4047506)をご覧ください。拡張保護の設定が正しくないと、Outlook の接続に問題が発生する可能性があります。
 
 ### Exchange Server SE CU1 に延期された機能
 
@@ -116,6 +116,32 @@ Exchange Server SE RTM が利用可能になった際には、インプレース
 <mark>Exchange Server 2019 CU15 のインストールを開始する前に、Exchange Server を再起動して、すべての Windows Server 更新プログラムが完全にインストールされていることを確認してください。</mark>
 
 CU をインストールした後は、常に利用可能な [SU](https://learn.microsoft.com/exchange/new-features/build-numbers-and-release-dates?view=exchserver-2019) を確認してインストールしてください。[Exchange Server Health Checker](https://aka.ms/ExchangeHealthChecker) も、追加の手順が必要かどうかを教えてくれます。
+
+### このリリースの既知の問題
+
+一部のお客様は、[ハイブリッド モダン認証 (HMA)](https://learn.microsoft.com/microsoft-365/enterprise/configure-exchange-server-for-hybrid-modern-authentication?view=o365-worldwide) を有効にしている場合、CU15 のインストール後に OWA/ECP のログインが **HTTP 401** エラーで機能しない状況が発生することがあります。
+
+影響を受ける場合は、次の回避策を使用できます。
+
+次のコマンドを使用して、OAuth を無効にします。
+
+``` PowerShell
+Get-EcpVirtualDirectory -Server server1 | Set-EcpVirtualDirectory -OAuthAuthentication $false
+Get-OwaVirtualDirectory -Server server1 | Set-OwaVirtualDirectory -OAuthAuthentication $false
+Restart-WebAppPool MSExchangeOWAAppPool
+Restart-WebAppPool MSExchangeECPAppPool
+```
+
+次に、以下のコマンドを使用して OAuth を再度有効化します。
+
+``` PowerShell
+Get-EcpVirtualDirectory -Server server1 | Set-EcpVirtualDirectory -OAuthAuthentication $true
+Get-OwaVirtualDirectory -Server server1 | Set-OwaVirtualDirectory -OAuthAuthentication $true
+Restart-WebAppPool MSExchangeOWAAppPool
+Restart-WebAppPool MSExchangeECPAppPool
+```
+
+*HMA を使用しているすべてのお客様がこの問題に直面するわけではありません*のでご注意ください。
 
 ## 追加情報
 

--- a/source/_posts/released-2025-h1-cumulative-update-for-exchange-server.md
+++ b/source/_posts/released-2025-h1-cumulative-update-for-exchange-server.md
@@ -1,7 +1,7 @@
 ---
 title: 'リリース: Exchange Server 2019 向け 2025 H1 累積更新プログラム'
 date: 2025-02-13
-lastupdate: 
+lastupdate: 2025-03-04
 tags: Exchange
 --- 
 
@@ -119,9 +119,9 @@ CU をインストールした後は、常に利用可能な [SU](https://learn.
 
 ### このリリースの既知の問題
 
-一部のお客様は、[ハイブリッド モダン認証 (HMA)](https://learn.microsoft.com/microsoft-365/enterprise/configure-exchange-server-for-hybrid-modern-authentication?view=o365-worldwide) を有効にしている場合、CU15 のインストール後に OWA/ECP のログインが **HTTP 401** エラーで機能しない状況が発生することがあります。
+一部のお客様は、[ハイブリッド モダン認証 (HMA)](https://learn.microsoft.com/microsoft-365/enterprise/configure-exchange-server-for-hybrid-modern-authentication?view=o365-worldwide) を有効にしている場合、CU15 のインストール後に OWA/ECP のログインが **HTTP 401** エラーで正常に動作しない場合があります。
 
-影響を受ける場合は、次の回避策を使用できます。
+この既知の問題の回避策は以下の通りです。
 
 次のコマンドを使用して、OAuth を無効にします。
 
@@ -141,7 +141,7 @@ Restart-WebAppPool MSExchangeOWAAppPool
 Restart-WebAppPool MSExchangeECPAppPool
 ```
 
-*HMA を使用しているすべてのお客様がこの問題に直面するわけではありません*のでご注意ください。
+※ *HMA を使用しているすべてのお客様がこの問題に直面するわけではありません*のでご注意ください。
 
 ## 追加情報
 

--- a/source/_posts/released-2025-h1-cumulative-update-for-exchange-server.md
+++ b/source/_posts/released-2025-h1-cumulative-update-for-exchange-server.md
@@ -111,7 +111,7 @@ Exchange Server SE RTM が利用可能になった際には、インプレース
 
 このリリースの修正内容と製品のダウンロードについては、以下の KB 記事をご覧ください：
 
-- Exchange Server 2019 Cumulative Update 15 (KB5042461), [VLSC](https://www.microsoft.com/Licensing/servicecenter/default.aspx), [Download](https://www.microsoft.com/download/details.aspx?familyID=8c3c7713-b480-4a5a-872f-e6c2987dd490)
+- Exchange Server 2019 Cumulative Update 15 (KB5042461), [VLSC](https://www.microsoft.com/Licensing/servicecenter/default.aspx), [Download](https://www.microsoft.com/download/details.aspx?id=106402)
 
 <mark>Exchange Server 2019 CU15 のインストールを開始する前に、Exchange Server を再起動して、すべての Windows Server 更新プログラムが完全にインストールされていることを確認してください。</mark>
 


### PR DESCRIPTION
Known Issue の追加と、拡張保護の既定の有効化の部分で元の記事に更新がありましたので、翻訳記事も更新します。

拡張保護
以前の記事:
As a reminder to our customers upgrading from older CUs, since Exchange 2019 CU14, Extended Protection is enabled by default after CU is installed. For more information as well as instructions on how to opt out of Extended Protection, please see this blog post.

現在の記事:
As a reminder to our customers upgrading from older CUs, since Exchange 2019 CU14, Extended Protection is enabled by default after CU is installed. **There are scenarios in which Extended Protection is not supported, such as using SSL Offloading.** For more information as well as instructions on how to opt out of Extended Protection, please see this blog post. I**ncorrect Extended Protection configuration can lead to Outlook connectivity issues.**

Known Issue は新規追加なので差分ではないです。

レビューをお願いいたします。