### PR TITLE
Update TERRL Schedure

### DIFF
--- a/source/_posts/introducing-exchange-online-tenant-outbound-email-limits.md
+++ b/source/_posts/introducing-exchange-online-tenant-outbound-email-limits.md
@@ -1,13 +1,13 @@
 ---
 title: 'Exchange Online テナントの外部送信メール制限の導入'
 date: 2025-02-26
-lastupdate: 2025-04-17
+lastupdate: 2025-06-11
 tags: Exchange Online
 ---
 ※ この記事は、[Introducing Exchange Online Tenant Outbound Email Limits](https://techcommunity.microsoft.com/blog/exchange/introducing-exchange-online-tenant-outbound-email-limits/4372797) の抄訳です。最新の情報はリンク先をご確認ください。この記事は Microsoft 365 Copilot および GitHub Copilot を使用して抄訳版の作成が行われています。
 
 <div style="margin:1.25em;border-left:.25em solid #4493f8;padding:.5em;">
-2025 年 4 月 15 日更新: ロールアウトのスケジュールを更新しました。
+2025 年 6 月 9 日更新: ロールアウトのスケジュールを更新しました。
 </div>
 
 クラウド サービス全般に言えることですが、Exchange Online では Exchange Online リソースの不正使用を防ぎ、すべてのユーザーに対して可用性を確保するためにサービスの制限を設けています。例えば、High-Volume Email の機能を除いて、Exchange Online は大量のメール送信をサポートしておらず、これまでは主にメールボックスごとの 1 日あたりの送信制限 (Recipient Rate Limit または RRL として知られています) を使用してこれを制限していました。
@@ -26,14 +26,14 @@ tags: Exchange Online
 | 1 | 25 メール ライセンス以下のテナント | 2025/4/3 |
 | 2 | 200 メール ライセンス以下のテナント | 2025/4/18 |
 | 3 | 500 メール ライセンス以下のテナント | 2025/4/28 |
-| 4 | すべてのテナント | 2025/5/9 |
+| 4 | すべてのテナント | <span style="color:red">一時的に展開を停止しています。</span> |
 
 **GCC 環境**のテナント:
 
 | | |
 | --- | --- |
-| EAC レポートの有効化 | 2025/5/30 |
-| 強制の有効化 | 2025/6/30 |
+| EAC レポートの有効化 | 2025/6/15 |
+| 強制の有効化 | 2025/7/30 |
 
 GCC 環境のお客様は、5 月末までレポートにアクセスしようとすると、レポートが空白であったり、まったく表示されなかったりするなど、一貫性のない体験をする可能性がありますのでご注意ください。
 


### PR DESCRIPTION
以下の記事の更新に合わせて翻訳を更新しました。
https://techcommunity.microsoft.com/blog/exchange/introducing-exchange-online-tenant-outbound-email-limits/4372797

更新箇所はスケジュールですが、500 ライセンス以上のテナントと、以前のアップデートで更新されていた GCC のテナントのスケジュールを合わせて更新しています。そのため、直近の差分情報の更新だけではない状況となっています。(念のため全文確認はしました。)