### PR TITLE
Update announcing-general-availability-ga-of-the-new-message-trace-in…

### DIFF
--- a/source/_posts/announcing-general-availability-ga-of-the-new-message-trace-in-exchange-online.md
+++ b/source/_posts/announcing-general-availability-ga-of-the-new-message-trace-in-exchange-online.md
@@ -1,7 +1,7 @@
 ---
 title: 'Exchange Online の新しいメッセージ追跡の一般提供 (GA) を発表'
 date: 2025-06-04
-lastupdate: 2025-06-10
+lastupdate: 2025-06-11
 tags: 'Exchange Online'
 ---
 

--- a/source/_posts/announcing-general-availability-ga-of-the-new-message-trace-in-exchange-online.md
+++ b/source/_posts/announcing-general-availability-ga-of-the-new-message-trace-in-exchange-online.md
@@ -15,8 +15,8 @@ Exchange Online のリソースの不正利用や濫用のリスクを低減し�
 
 | コマンドレット | テナント レベルの制限 |
 | --- | --- |
-| Get-MesesageTraceV2 | 5 分あたり最大 100 件のリクエスト |
-| Get-MessageTraceDetailV2 | 5 分あたり最大 100 件のリクエスト |
+| <a class="lia-external-url" href="https://learn.microsoft.com/en-us/powershell/module/exchange/get-messagetracev2?view=exchange-ps" target="_blank" rel="noopener noreferrer">Get-MesesageTraceV2</a> | 5 分あたり最大 100 件のリクエスト |
+| <a class="lia-external-url" href="https://learn.microsoft.com/en-us/powershell/module/exchange/get-messagetracedetailv2?view=exchange-ps" target="_blank" rel="noopener noreferrer">Get-MessageTraceDetailV2</a> | 5 分あたり最大 100 件のリクエスト |
 
 ## 従来のメッセージ追跡インターフェイスおよびコマンドレットの廃止スケジュール
 


### PR DESCRIPTION
以下の記事の更新に合わせて翻訳記事を修正しました。
https://techcommunity.microsoft.com/blog/exchange/announcing-general-availability-ga-of-the-new-message-trace-in-exchange-online/4420243

修正箇所はスロットリングの表の中の文字列のリンク化のみです。