### PR TITLE
Update introducing-exchange-online-tenant-outbound-email-limits

### DIFF
--- a/source/_posts/introducing-exchange-online-tenant-outbound-email-limits.md
+++ b/source/_posts/introducing-exchange-online-tenant-outbound-email-limits.md
@@ -7,7 +7,7 @@ tags: Exchange Online
 ※ この記事は、[Introducing Exchange Online Tenant Outbound Email Limits](https://techcommunity.microsoft.com/blog/exchange/introducing-exchange-online-tenant-outbound-email-limits/4372797) の抄訳です。最新の情報はリンク先をご確認ください。この記事は Microsoft 365 Copilot および GitHub Copilot を使用して抄訳版の作成が行われています。
 
 <div style="margin:1.25em;border-left:.25em solid #4493f8;padding:.5em;">
-2025 年 6 月 9 日更新: ロールアウトのスケジュールを更新しました。
+2025 年 7 月 14 日更新: FAQ を更新しました。
 </div>
 
 クラウド サービス全般に言えることですが、Exchange Online では Exchange Online リソースの不正使用を防ぎ、すべてのユーザーに対して可用性を確保するためにサービスの制限を設けています。例えば、High-Volume Email の機能を除いて、Exchange Online は大量のメール送信をサポートしておらず、これまでは主にメールボックスごとの 1 日あたりの送信制限 (Recipient Rate Limit または RRL として知られています) を使用してこれを制限していました。
@@ -139,7 +139,7 @@ TERRL はメール ライセンスの総数に基づきます。
 1,000 人としてカウントされます。外部受信者のカウントは、配布グループ (およびそのネストされたグループ) が個々の受信者に完全に展開された後に行われます。
 
 **Exchange Online High-Volume email (HVE) を使用して送信された外部受信者へのメッセージは TERRL クォータにカウントされますか？**  
-いいえ。HVE は主に内部受信者への大量メール送信を目的としていますが、1 日あたり最大 2,000 人の外部受信者への送信もサポートしています。HVE を使用して外部受信者に送信されたメッセージは TERRL クォータにはカウントされません。
+いいえ。HVE は主に内部受信者への大量メール送信を目的とした機能です。外部受信者への送信には設計されていません。
 
 **テナント内の上位送信者を特定するにはどうすればよいですか？**  
 Microsoft Defender ポータルの「上位送信者と受信者」レポート (Microsoft Defender &gt; レポート &gt; Email & collaboration reports &gt; 上位送信者と受信者) を使用するか、EAC のメッセージ トレースを使用して上位送信者のリストを集計できます。また、今年後半にテナント外部受信者レート レポートに上位送信者リストを追加することも検討しています。

--- a/source/_posts/introducing-exchange-online-tenant-outbound-email-limits.md
+++ b/source/_posts/introducing-exchange-online-tenant-outbound-email-limits.md
@@ -1,7 +1,7 @@
 ---
 title: 'Exchange Online テナントの外部送信メール制限の導入'
 date: 2025-02-26
-lastupdate: 2025-06-18
+lastupdate: 2025-07-15
 tags: Exchange Online
 ---
 ※ この記事は、[Introducing Exchange Online Tenant Outbound Email Limits](https://techcommunity.microsoft.com/blog/exchange/introducing-exchange-online-tenant-outbound-email-limits/4372797) の抄訳です。最新の情報はリンク先をご確認ください。この記事は Microsoft 365 Copilot および GitHub Copilot を使用して抄訳版の作成が行われています。


### PR DESCRIPTION
以下の記事の更新に合わせて翻訳記事を更新しました。

https://techcommunity.microsoft.com/blog/exchange/introducing-exchange-online-tenant-outbound-email-limits/4372797

更新箇所は FAQ と冒頭の更新箇所を知らせる部分と Last Update です。