### PR TITLE
fix: copilot-instructions の date フロントマター形式を修正

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,15 +14,15 @@
 ```yaml
 ---
 title: "記事タイトル"
-date: YYYY/MM/DD HH:mm
-lastupdate: YYYY/MM/DD
+date: YYYY-MM-DD HH:mm
+lastupdate: YYYY-MM-DD
 tags:
 - タグ名
 ---
 ```
 
 - `title`: 日本語タイトル。コロンを含む場合はダブルクォートで囲む
-- `date`: 公開日時
+- `date`: 公開日時。形式は `YYYY-MM-DD HH:mm`（例: `2026-07-08 11:00`）。時刻を含めることで同日に複数の記事がある場合の並び順が正確になるため、時刻も含めることを推奨する。時刻が不明な場合は `YYYY-MM-DD` の日付のみでも可。
 - `lastupdate`: 更新日 (更新がない場合は空欄、もしくは lastupdate フィールド自体を省略)
 - `tags`: Exchange, Exchange Online, Outlook, New Outlook など
 - ファイル名は英語のケバブケース (例: `released-february-2026-exchange-server-security-updates.md`)


### PR DESCRIPTION
YAML 仕様と実際の記事ファイルの形式に合わせ、`copilot-instructions.md` の `date` および `lastupdate` フィールドのフォーマット記載を修正しました。

**修正内容:**

- 区切り文字をスラッシュ (`/`) からハイフン (`-`) に変更 (`YYYY/MM/DD` -> `YYYY-MM-DD`)
- `lastupdate` も同様に修正
- `date` フィールドの説明に以下を追記:
  - 推奨形式と具体例 (`YYYY-MM-DD HH:mm`)
  - 時刻を含める理由 (同日複数記事の並び順の正確さ)
  - 時刻が不明な場合は日付のみでも可という旨

**背景:**

`hexo-front-matter` の YAML タイムスタンプパーサーはハイフン区切りのみを正式なタイムスタンプとして認識します。スラッシュ形式は YAML 文字列として扱われ、後段の moment.js で解析されるため動作はしますが非標準です。Hexo の `formatDate()` 関数もハイフン・ゼロ埋め形式を出力しており、リポジトリ内の既存記事もすべてハイフン形式で統一されていました。